### PR TITLE
feat(release): スクショ全削除 clear_screenshots レーン＋ワークフロー（再コミット）

### DIFF
--- a/.github/workflows/ios-appstore-clear-screenshots.yml
+++ b/.github/workflows/ios-appstore-clear-screenshots.yml
@@ -1,0 +1,45 @@
+name: iOS App Store Clear Screenshots
+
+# 手動トリガー。該当バージョンのスクリーンショットを全削除して 0 枚にする。
+# App Store Connect の画面で削除できない/重複した時の掃除用。掃除後にクリーンな6枚を入れ直す。
+#   gh workflow run ios-appstore-clear-screenshots.yml -f version=1.1.4
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "スクショを全削除する Marketing version, 例: 1.1.4"
+        required: true
+        type: string
+
+concurrency:
+  group: ios-appstore-screenshots
+  cancel-in-progress: false
+
+jobs:
+  clear:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ModernJamaica
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby (bundler cache)
+        uses: ruby/setup-ruby@v1
+        with:
+          # lock が Ruby<3.2 前提のため 3.1 に合わせる。
+          ruby-version: "3.1"
+          bundler-cache: true
+          working-directory: ModernJamaica
+
+      - name: Write App Store Connect API key
+        run: |
+          echo "${{ secrets.APP_STORE_CONNECT_KEY_BASE64 }}" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+
+      - name: Clear all screenshots
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+        run: |
+          bundle exec fastlane ios clear_screenshots version:"${{ inputs.version }}"

--- a/ModernJamaica/fastlane/Fastfile
+++ b/ModernJamaica/fastlane/Fastfile
@@ -179,4 +179,44 @@ platform :ios do
 
     UI.success("Submitted #{version} for review. 承認後に自動公開されます。")
   end
+
+  desc "スクショを全削除して 0 枚にする（App Store Connect の画面で消せない時の掃除用）"
+  desc "使い方: bundle exec fastlane ios clear_screenshots version:1.1.4"
+  desc ""
+  desc "空のスクショフォルダで overwrite するため、既存スクショを全削除してアップロードは 0。"
+  desc "削除は結果整合性の競合を起こさないので確実。掃除後にクリーンな6枚を入れ直す。"
+  lane :clear_screenshots do |options|
+    key_id    = ENV.fetch("ASC_KEY_ID")
+    issuer_id = ENV.fetch("ASC_ISSUER_ID")
+    key_path  = File.expand_path(ENV.fetch("ASC_KEY_PATH"))
+
+    api_key = app_store_connect_api_key(
+      key_id: key_id,
+      issuer_id: issuer_id,
+      key_filepath: key_path,
+      duration: 1200,
+    )
+
+    version = (options[:version] ||
+      get_info_plist_value(path: "ios/ModernJamaica/Info.plist", key: "CFBundleShortVersionString")).to_s.strip
+    UI.user_error!("marketing version が空です。version:X.Y.Z を渡してください") if version.empty?
+    UI.important("Clearing ALL screenshots for #{version} (uploading 0)")
+
+    upload_to_app_store(
+      api_key: api_key,
+      app_identifier: APP_ID,
+      app_version: version,
+      skip_binary_upload: true,
+      skip_metadata: true,
+      # 空フォルダで上書き＝全削除・アップロード0。
+      overwrite_screenshots: true,
+      screenshots_path: "./fastlane/screenshots-empty",
+      languages: ["ja"],
+      force: true,
+      run_precheck_before_submit: false,
+      submit_for_review: false,
+    )
+
+    UI.success("Cleared all screenshots for #{version}. App Store Connect でクリーンな6枚を入れ直してください。")
+  end
 end


### PR DESCRIPTION
前回 PR #7 で git add のミスにより lane/ワークフロー本体が入っていなかったため入れ直す。ASC のスクショを確実に全削除(0枚)する掃除用。deliver の削除は競合しないため確実。

🤖 Generated with [Claude Code](https://claude.com/claude-code)